### PR TITLE
Enforce java version by setting compatability in all compile tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,11 @@ allprojects {
 
 subprojects { subproj ->
     apply plugin: 'java'
+    tasks.withType(JavaCompile) {
+        sourceCompatibility = rootProject.sourceCompatibility
+        targetCompatibility = rootProject.targetCompatibility
+    }
+
     apply from: rootProject.file('gradle/code-quality.gradle')
     apply plugin: 'info.solidsoft.pitest'
 


### PR DESCRIPTION
Sorry to break your build. But there is Java 8 code in your project. This change will enforce the Java version and cause the project to no longer compile.

This pull request does not compile intentionally. I was not sure if I should fix the code to be 1.7 compatible or raise the project to 1.8
